### PR TITLE
Fixes for fetching the catalog, thumbnails and a cooldown deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Pull requests welcome.
 
 #### To do
 
-- Test the 1 second request cooldown
 - More useful `Thread` and `*Post` methods
 - Update & add more tests
 - ...

--- a/api/api.go
+++ b/api/api.go
@@ -559,6 +559,9 @@ func GetCatalog(board string) (Catalog, error) {
 			post := json_to_native(post, thread)
 			thread.Posts[0] = post
 			extracted.Threads[j] = thread
+			if thread.OP == nil {
+				thread.OP = thread.Posts[0]
+			}
 		}
 		cat[i] = extracted
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -543,7 +543,7 @@ func GetCatalog(board string) (Catalog, error) {
 		return nil, fmt.Errorf("api: GetCatalog: No board name given")
 	}
 	var c catalog
-	err := getDecode(APIURL, fmt.Sprintf("/%s/catalog.json", board), c, nil)
+	err := getDecode(APIURL, fmt.Sprintf("/%s/catalog.json", board), &c, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -226,13 +226,17 @@ type Thread struct {
 // GetIndex hits the API for an index of thread stubs from the given board and
 // page.
 func GetIndex(board string, page int) ([]*Thread, error) {
-	resp, err := get(APIURL, fmt.Sprintf("/%s/%d.json", board, page), nil)
+	resp, err := get(APIURL, fmt.Sprintf("/%s/%d.json", board, page + 1), nil)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	threads, err := ParseIndex(resp.Body, board)
+	if err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 	for _, t := range threads {
 		t.date_recieved = now
@@ -254,9 +258,10 @@ func GetThreads(board string) ([][]int64, error) {
 	}
 	n := make([][]int64, len(p))
 	for _, page := range p {
-		n[page.Page] = make([]int64, len(page.Threads))
+		// Pages are 1 based in the json api
+		n[page.Page-1] = make([]int64, len(page.Threads))
 		for j, thread := range page.Threads {
-			n[page.Page][j] = thread.No
+			n[page.Page-1][j] = thread.No
 		}
 	}
 	return n, nil

--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,6 @@ var (
 const (
 	APIURL    = "a.4cdn.org"
 	ImageURL  = "i.4cdn.org"
-	ThumbURL  = "t.4cdn.org"
 	StaticURL = "s.4cdn.org"
 )
 
@@ -178,7 +177,7 @@ func (self *Post) ThumbURL() string {
 		return ""
 	}
 	return fmt.Sprintf("%s%s/%s/%ds%s",
-		prefix(), ThumbURL, self.Thread.Board, file.Id, file.Ext)
+		prefix(), ImageURL, self.Thread.Board, file.Id, ".jpg")
 }
 
 // A File represents an uploaded file's metadata.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -32,7 +32,7 @@ func TestParseThread(t *testing.T) {
 	imageURL := thread.OP.ImageURL()
 	assert(t, imageURL == "http://i.4cdn.org/ck/1346968817055.jpg", "Image URL should be 'http://i.4cdn.org/ck/1346968817055.jpg' (got '"+imageURL+"')")
 	thumbURL := thread.OP.ThumbURL()
-	assert(t, thumbURL == "http://t.4cdn.org/ck/1346968817055s.jpg", "Thumb URL should be 'http://t.4cdn.org/ck/1346968817055s.jpg' (got '"+thumbURL+"')")
+	assert(t, thumbURL == "http://i.4cdn.org/ck/1346968817055s.jpg", "Thumb URL should be 'http://i.4cdn.org/ck/1346968817055s.jpg' (got '"+thumbURL+"')")
 }
 
 func TestGetIndex(t *testing.T) {


### PR DESCRIPTION
I used the library quite a bit and found and solved some issues I want to share. Please see the commits individually for better focus.

- Initialized thead.OP in GetCatalog just like when parsing the index for consistency
- Fixed getting the catalog
- Fixed thumbnail URL creation, all thumbs are now jpgs and t.4cdn.org is gone.
- Secured the cooldown channel and timer setting a mutex since there was a race condition between reading the cooldown timer value and setting the new value which could result in a deadlock.
